### PR TITLE
Fix lint configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "./node_modules/.bin/eslint --ext ./src && ./node_modules/.bin/prettier --check ./src",
-    "lint:fix": "./node_modules/.bin/eslint --fix --ext ./src && ./node_modules/.bin/prettier --write ./src",
+    "lint": "./node_modules/.bin/eslint ./src --ext .js,.jsx,.ts,.tsx && ./node_modules/.bin/prettier --check ./src",
+    "lint:fix": "./node_modules/.bin/eslint --fix ./src --ext .js,.jsx,.ts,.tsx && ./node_modules/.bin/prettier --write ./src",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -40,7 +40,7 @@
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": "eslint --fix",
-    "src/**/*.{js,jsx,,ts,tsx,css,md}": "prettier --write"
+    "src/**/*.{js,jsx,ts,tsx,css,md}": "prettier --write"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Summary
- update lint scripts to use proper `--ext` argument
- correct `lint-staged` globs

## Testing
- `npm run lint` *(fails: ./node_modules/.bin/eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842952d98348333899226a312223d36